### PR TITLE
Update bundler gem requirement to >= v2.2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ rvm:
   - jruby-head
   - ree
 bundler_args: --binstubs
+before_install:
+    - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - rbx-5
   - jruby
   - jruby-head
-  - ree
 bundler_args: --binstubs
 before_install:
     - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ rvm:
   - ruby-head
   - jruby-18mode
   - jruby-19mode
-  - rbx-18mode
-  - rbx-19mode
+  - rbx-4
+  - rbx-5
   - jruby-head
   - ree
 bundler_args: --binstubs

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - ruby-head
   - jruby
   - jruby-head
-  - mruby-head
 bundler_args: --binstubs
 before_install:
     - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 1.9.3
+  - 3.0.1
+  - 2.7.3
+  - ruby-head
   - jruby-18mode
   - jruby-19mode
   - rbx-18mode
   - rbx-19mode
-  #- ruby-head # Currently dying with the following returned:
-               # Unable to download data from https://rubygems.org/ - no such name (https://rubygems.org/latest_specs.4.8.gz)
   - jruby-head
-  - 1.8.7
   - ree
 bundler_args: --binstubs

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ rvm:
   - 3.0.1
   - 2.7.3
   - ruby-head
-  - rbx-4
-  - rbx-5
   - jruby
   - jruby-head
+  - mruby-head
 bundler_args: --binstubs
 before_install:
     - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ rvm:
   - 3.0.1
   - 2.7.3
   - ruby-head
-  - jruby-18mode
-  - jruby-19mode
   - rbx-4
   - rbx-5
+  - jruby
   - jruby-head
   - ree
 bundler_args: --binstubs

--- a/mozart-rails.gemspec
+++ b/mozart-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 2.2.10"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"

--- a/mozart-rails.gemspec
+++ b/mozart-rails.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.name          = "mozart-rails"
   spec.version       = Mozart::Rails::VERSION
   spec.authors       = ["Sasha Gerrand"]
-  spec.email         = ["sasha.gerrand@bigcommerce.com"]
+  spec.email         = ["rubygems-mozart-rails@sgerrand.com"]
   spec.description   = %q{Use Mozart with Rails 3}
   spec.summary       = %q{This gem provides the Mozart JavaScript framework for your Rails 3 application.}
   spec.homepage      = "https://mozart.io"


### PR DESCRIPTION
💁 Updates the minimum `bundler` version to 2.2.10 or later to resolve:
* CVE-2019-3881: https://github.com/advisories/GHSA-g98m-96g9-wfjq
* CVE-2020-36327: https://github.com/advisories/GHSA-fp4w-jxhp-m23p