### PR TITLE
Update Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 language: ruby
 rvm:
-  - 2.0.0
-  - 1.9.3
+  - 3.0.1
+  - 2.7.3
+  - ruby-head
   - jruby-18mode
   - jruby-19mode
   - rbx-18mode
   - rbx-19mode
-  #- ruby-head # Currently dying with the following returned:
-               # Unable to download data from https://rubygems.org/ - no such name (https://rubygems.org/latest_specs.4.8.gz)
   - jruby-head
-  - 1.8.7
   - ree
 bundler_args: --binstubs


### PR DESCRIPTION
💁 These changes update the Travis CI build configuration for this package:
* Update Ruby versions to the current generally available versions (2.7.3, 3.0.1)